### PR TITLE
Add max-width none to flag__img

### DIFF
--- a/_objects.flag.scss
+++ b/_objects.flag.scss
@@ -56,6 +56,7 @@ $inuit-flag-collapse-at:        720px !default;
     .#{$inuit-namespace}flag__img,
     %#{$inuit-namespace}flag__img {
         padding-right: $inuit-flag-gutter;
+        max-width: none;
 
         > img {
             display: block;


### PR DESCRIPTION
Helpful if you add the class "flag__img" directly to the img element.
