### PR TITLE
Remove unnecessary margins

### DIFF
--- a/_objects.flag.scss
+++ b/_objects.flag.scss
@@ -72,6 +72,12 @@ $inuit-flag-collapse-at:        720px !default;
     .#{$inuit-namespace}flag__body,
     %#{$inuit-namespace}flag__body {
         width: 100%; /* [1] */
+
+        &,
+        > :last-child {
+            margin-bottom: 0;
+        }
+
     }
 
 


### PR DESCRIPTION
Hi Harry,

I used the `flag` object in a project and I've some issue with vertical alignement. I believe that in most cases HTML elements present in `flag__body` will have bottom margin and create a bad visual rendering.

I forked your `flag` jsfiddle to illustrate my question : http://jsfiddle.net/florianbouvot/LY94Z/3/

I think that by default the `flag` object can remove the bottom margin of the last element in the body (like in the `media` object). What do you think ?

Thanks, Florian.
